### PR TITLE
fix: correctly pass the array of arguments in the throttled function

### DIFF
--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -9,6 +9,6 @@ export function debounce<T extends (...args: any[]) => void>(
       clearTimeout(timeoutId)
     }
 
-    timeoutId = setTimeout(() => fn(args), ms)
+    timeoutId = setTimeout(() => fn(...args), ms)
   }
 }

--- a/src/throttle.ts
+++ b/src/throttle.ts
@@ -9,7 +9,7 @@ export function throttle<T extends (...args: any[]) => ReturnType<T>>(
     if (!isThrottle) {
       isThrottle = true
       setTimeout(() => (isThrottle = false), ms)
-      lastResult = fn(args)
+      lastResult = fn(...args)
     }
 
     return lastResult


### PR DESCRIPTION
Was one problem with throttled function: passed on incorrect array of arguments for throttled function, see [exmaple](https://codesandbox.io/s/throttle-bug-gdvwjg?file=/src/index.js)
I waiting see two argument in console: **'asdasd', MouseEvent**
I recived two aruments in console: **['asdasd', MouseEvent], undefined** 

I think this is a bug